### PR TITLE
feat: added profile update banner

### DIFF
--- a/apps/web/app/(dashboard)/home/layout.tsx
+++ b/apps/web/app/(dashboard)/home/layout.tsx
@@ -1,7 +1,11 @@
-import { getCurrentUser } from '@/utils/user';
-import { Roles } from '@prisma/client';
+'use client';
 
-export default async function DashboardLayout({
+import ProfileBanner from '@/components/settings/ProfileBanner';
+import { getCurrentUser, UserState } from '@/utils/user';
+import { Roles } from '@prisma/client';
+import { useEffect, useState } from 'react';
+
+export default function DashboardLayout({
   superUser,
   taskAgent,
   client,
@@ -12,9 +16,23 @@ export default async function DashboardLayout({
   client: React.ReactNode;
   taskSupervisor: React.ReactNode;
 }) {
-  const user = await getCurrentUser();
+  const [user, setUser] = useState<UserState | null>(null);
+  useEffect(() => {
+    const fetchDependencies = async () => {
+      const loggedInUser = await getCurrentUser();
+      setUser(loggedInUser);
+    };
+    fetchDependencies();
+  }, []);
+  console.log('user', user);
+  const showBanner =
+    user?.role?.name === Roles.CLIENT
+      ? !user?.avatarUrl || !user?.bio
+      : !user?.avatarUrl || !user?.bio || !user?.userSkills || user?.userSkills.length === 0;
+
   return (
     <div>
+      {user && showBanner && <ProfileBanner />}
       <div>{user?.role?.name === Roles.TASK_SUPERVISOR ? taskSupervisor : null}</div>
       <div>{user?.role?.name === Roles.SUPER_USER ? superUser : null}</div>
       <div>{user?.role?.name === Roles.TASK_AGENT ? taskAgent : null}</div>

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -33,8 +33,8 @@ body {
     --muted-foreground: 220 8.9% 46.1%;
     --accent: 220 14.3% 95.9%;
     --accent-foreground: 220.9 39.3% 11%;
-	--ghost: 210 20% 98%;
-	--ghost-foreground: 210 20% 20%;
+    --ghost: 210 20% 98%;
+    --ghost-foreground: 210 20% 20%;
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 210 20% 98%;
     --success: 142 76% 36%;
@@ -79,8 +79,8 @@ body {
     --muted-foreground: 217.9 10.6% 64.9%;
     --accent: 215 27.9% 16.9%;
     --accent-foreground: 210 20% 98%;
-	--ghost: 210 20% 20%;
-	--ghost-foreground: 210 20% 98%;
+    --ghost: 210 20% 20%;
+    --ghost-foreground: 210 20% 98%;
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 210 20% 98%;
     --success: 142 76% 36%;
@@ -496,6 +496,9 @@ body {
   @apply ring-2 ring-blue-500 ring-offset-2 ring-offset-background;
   animation: mentionPulse 0.6s ease-in-out;
 }
+.profile-banner {
+  animation: profileBannerAnimation 3s ease-in-out infinite;
+}
 
 @keyframes mentionPulse {
   0%,
@@ -506,5 +509,19 @@ body {
   50% {
     transform: scale(1.02);
     opacity: 0.9;
+  }
+}
+@keyframes profileBannerAnimation {
+  0% {
+    opacity: 1;
+    background-color: transparent;
+  }
+  50% {
+    opacity: 0.7;
+    background-color: hsla(259, 63%, 59%, 0.1);
+  }
+  100% {
+    opacity: 1;
+    background-color: transparent;
   }
 }

--- a/apps/web/components/settings/ProfileBanner.tsx
+++ b/apps/web/components/settings/ProfileBanner.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { UserCircle2 } from 'lucide-react';
+import { Card } from '../ui/card';
+import { Button } from '../ui/button';
+import { useRouter } from 'next/navigation';
+export default function ProfileBanner() {
+  const router = useRouter();
+  const handleUpdateProfile = () => {
+    router.push('/settings/myprofile');
+  };
+  return (
+    <Card className="h-[70px] rounded-2xl p-2 px-3 shadow-m flex mx-4 items-center justify-between profile-banner">
+      <div className="flex items-center gap-3">
+        <div className="rounded-xl p-2 border-2 border-primary">
+          <UserCircle2 className="w-6 h-6 text-primary" />
+        </div>
+        <div className="flex-col gap-1">
+          <h2 className="text-lg font-semibold"> Finish Your Profile</h2>
+          <p className="text-sm text-muted-foreground">
+            Please update your profile to ensure a seamless integration with our system.
+          </p>
+        </div>
+      </div>
+      <Button onClick={handleUpdateProfile}>Update Profile</Button>
+    </Card>
+  );
+}

--- a/apps/web/utils/authTools.ts
+++ b/apps/web/utils/authTools.ts
@@ -50,6 +50,8 @@ export const getUserFromToken = async (token: { name: string; value: string }) =
         firstName: true,
         lastName: true,
         avatarUrl: true,
+        bio: true,
+        userSkills: true,
         role: {
           select: {
             id: true,
@@ -71,6 +73,7 @@ export const getUserFromToken = async (token: { name: string; value: string }) =
           contactName: true,
           avatarUrl: true,
           email: true,
+          bio: true,
           role: {
             select: {
               id: true,
@@ -88,6 +91,7 @@ export const getUserFromToken = async (token: { name: string; value: string }) =
         username: client.username,
         email: client.email,
         avatarUrl: client.avatarUrl,
+        bio: client.bio,
         role: {
           id: client.role?.id,
           name: client.role?.name,
@@ -101,6 +105,8 @@ export const getUserFromToken = async (token: { name: string; value: string }) =
       username: user.username,
       email: user.email,
       avatarUrl: user.avatarUrl,
+      bio: user.bio,
+      userSkills: user.userSkills,
       role: {
         id: user.role?.id,
         name: user.role?.name,

--- a/apps/web/utils/user.ts
+++ b/apps/web/utils/user.ts
@@ -4,13 +4,15 @@ import { redirect } from 'next/navigation';
 import { getUserFromToken } from './authTools';
 import { cache } from 'react';
 import { COOKIE_NAME } from './constant';
-import { Roles } from '@prisma/client';
+import { Roles, UserSkill } from '@prisma/client';
 export interface UserState {
   id: string;
   name?: string;
   username: string;
   email: string;
   avatarUrl: string | null;
+  userSkills?: UserSkill[];
+  bio: string | null;
   role: {
     name: Roles | undefined;
   } | null;


### PR DESCRIPTION
**Files Modified:**
1-apps/web/app/(dashboard)/home/layout.tsx
2-apps/web/app/globals.css
3-apps/web/components/settings/ProfileBanner.tsx (new file)
4-apps/web/utils/authTools.ts
5-apps/web/utils/user.ts

**Approach:**
I developed a banner in the home page which prompts user to complete profile to ensure seamless integration with the system. This banner takes user to the profile page where he should update his profile image, bio and skills (excluding client). The banner disappears if user updates these sections. 

**Alternatives:**
We could have showed a pop up when user logs in just like the notification pop up. But this method is not good as used is being shown notification pop up already and to show another pop up is not good for the user experience.

**Reproduction Steps:**
- Login to the website or signup with a new user.
- Banner will be shown in the top of the home page advising user to update profile. 
- Clicking on the button will take the user to the profile page where he has to update profile image, bio and skills set(not for client).
- After updating these fields, banner will disappear from the home page.
- If user does not update even one of these fields then he will still see the banner on home page.

**Recording:**
https://www.loom.com/share/da8985671ef84736a280b64166b5ad30?sid=6fb482e9-fda8-4316-814f-040ff62f3fa8