### PR TITLE
feat: task supervisor permission updated and assignee retriaval list …

### DIFF
--- a/apps/backend/api/services/task.service.ts
+++ b/apps/backend/api/services/task.service.ts
@@ -85,7 +85,7 @@ export class TaskService {
     const queryOptions: TaskQueryOptions = {
       cursor,
       pageSize,
-      orderBy: { id: 'asc' },
+      orderBy: { createdAt: 'desc' },
     };
 
     // Execute queries

--- a/apps/web/.turbo/turbo-build.log
+++ b/apps/web/.turbo/turbo-build.log
@@ -5,12 +5,17 @@
 Environment variables loaded from .env
 Prisma schema loaded from prisma\schema.prisma
 
-✔ Generated Prisma Client (v6.15.0) to .\..\..\node_modules\.pnpm\@prisma+client@6.15.0_prisma@6.15.0_magicast@0.3.5_typescript@5.6.3__typescript@5.6.3\node_modules\@prisma\client in 666ms
+✔ Generated Prisma Client (v6.16.3) to .\..\..\node_modules\.pnpm\@prisma+client@6.16.3_prisma@6.16.3_magicast@0.3.5_typescript@5.6.3__typescript@5.6.3\node_modules\@prisma\client in 715ms
 
 Start by importing your Prisma Client (See: https://pris.ly/d/importing-client)
 
-Tip: Want to turn off tips and other hints? https://pris.ly/tip-4-nohints
+Tip: Need your database queries to be 1000x faster? Accelerate offers you that and more: https://pris.ly/tip-2-accelerate
 
+npm notice
+npm notice New major version of npm available! 10.9.0 -> 11.6.1
+npm notice Changelog: https://github.com/npm/cli/releases/tag/v11.6.1
+npm notice To update run: npm install -g npm@11.6.1
+npm notice
 
 > web@0.1.0 build:cdk D:\STUDY RELATED\HillCountryCoders\whatsnextplease-monolith\apps\web
 > npm --prefix cdk run build
@@ -23,7 +28,7 @@ Environment variables loaded from .env
 Prisma schema loaded from prisma\schema.prisma
 Datasource "db": PostgreSQL database "wnpdb_dev", schema "public" at "localhost:5433"
 
-35 migrations found in prisma/migrations
+37 migrations found in prisma/migrations
 
 
 No pending migrations to apply.
@@ -35,19 +40,11 @@ No pending migrations to apply.
 [1m[33mwarn[39m[22m - The safelist pattern `/^hover:bg-(red|green|blue|yellow|orange|purple|cyan|gray)-(300|400|500|600|700|800)$/` doesn't match any Tailwind CSS classes.
 [1m[33mwarn[39m[22m - Fix this pattern or remove it from your `safelist` configuration.
 [1m[33mwarn[39m[22m - https://tailwindcss.com/docs/content-configuration#safelisting-classes
- ⚠ Compiled with warnings
-
-../../node_modules/.pnpm/@prisma+client@6.15.0_prisma@6.15.0_magicast@0.3.5_typescript@5.6.3__typescript@5.6.3/node_modules/@prisma/client/runtime/wasm-engine-edge.js
-A Node.js API is used (setImmediate at line: 11) which is not supported in the Edge Runtime.
-Learn more: https://nextjs.org/docs/api-reference/edge-runtime
-
-Import trace for requested module:
-../../node_modules/.pnpm/@prisma+client@6.15.0_prisma@6.15.0_magicast@0.3.5_typescript@5.6.3__typescript@5.6.3/node_modules/@prisma/client/runtime/wasm-engine-edge.js
-../../node_modules/.pnpm/@prisma+client@6.15.0_prisma@6.15.0_magicast@0.3.5_typescript@5.6.3__typescript@5.6.3/node_modules/.prisma/client/wasm.js
-../../node_modules/.pnpm/@prisma+client@6.15.0_prisma@6.15.0_magicast@0.3.5_typescript@5.6.3__typescript@5.6.3/node_modules/.prisma/client/default.js
-../../node_modules/.pnpm/@prisma+client@6.15.0_prisma@6.15.0_magicast@0.3.5_typescript@5.6.3__typescript@5.6.3/node_modules/@prisma/client/default.js
-
+ ✓ Compiled successfully
    Linting and checking validity of types ...
+
+./app/(auth)/verify-email/page.tsx
+25:6  Warning: React Hook useEffect has a missing dependency: 'verifyEmail'. Either include it or remove the dependency array.  react-hooks/exhaustive-deps
 
 ./app/(dashboard)/clients/data-table.tsx
 61:6  Warning: React Hook useEffect has a missing dependency: 'fetchClients'. Either include it or remove the dependency array.  react-hooks/exhaustive-deps
@@ -84,7 +81,8 @@ Import trace for requested module:
 68:9  Warning: The 'toggleLink' function makes the dependencies of useEffect Hook (at line 119) change on every render. To fix this, wrap the definition of 'toggleLink' in its own useCallback() Hook.  react-hooks/exhaustive-deps
 
 ./components/common/EditTaskDialog.tsx
-394:6  Warning: React Hook useEffect has missing dependencies: 'fetchSkills', 'fetchTaskMetadata', and 'fetchUsers'. Either include them or remove the dependency array.  react-hooks/exhaustive-deps
+394:6  Warning: React Hook useEffect has missing dependencies: 'fetchSkills' and 'fetchTaskMetadata'. Either include them or remove the dependency array.  react-hooks/exhaustive-deps
+398:6  Warning: React Hook useEffect has a missing dependency: 'fetchUsers'. Either include it or remove the dependency array.  react-hooks/exhaustive-deps
 
 ./components/files/FilePreviewModal.tsx
 292:6  Warning: React Hook useEffect has a missing dependency: 'currentFile'. Either include it or remove the dependency array.  react-hooks/exhaustive-deps
@@ -96,8 +94,9 @@ Import trace for requested module:
 217:6  Warning: React Hook useEffect has missing dependencies: 'toast' and 'token'. Either include them or remove the dependency array.  react-hooks/exhaustive-deps
 
 ./components/tasks/CreateTaskContainer.tsx
-120:6  Warning: React Hook useEffect has a missing dependency: 'getDefaultValues'. Either include it or remove the dependency array.  react-hooks/exhaustive-deps
-307:6  Warning: React Hook useEffect has missing dependencies: 'form', 'router', and 'toast'. Either include them or remove the dependency array.  react-hooks/exhaustive-deps
+121:6  Warning: React Hook useEffect has a missing dependency: 'getDefaultValues'. Either include it or remove the dependency array.  react-hooks/exhaustive-deps
+306:6  Warning: React Hook useEffect has missing dependencies: 'form', 'router', and 'toast'. Either include them or remove the dependency array.  react-hooks/exhaustive-deps
+349:6  Warning: React Hook useEffect has missing dependencies: 'form', 'toast', and 'user?.role?.name'. Either include them or remove the dependency array.  react-hooks/exhaustive-deps
 
 ./components/tasks/TasksListModal.tsx
 67:6  Warning: React Hook useEffect has a missing dependency: 'fetchTasks'. Either include it or remove the dependency array.  react-hooks/exhaustive-deps
@@ -113,8 +112,22 @@ Import trace for requested module:
 
 info  - Need to disable some ESLint rules? Learn more here: https://nextjs.org/docs/basic-features/eslint#disabling-rules
    Collecting page data ...
-   Generating static pages (0/31) ...
-   Generating static pages (7/31) 
+   Generating static pages (0/35) ...
+node:events:496
+      throw er; // Unhandled 'error' event
+      ^
+
+TypeError: destination.write is not a function
+    at run (D:\STUDY RELATED\HillCountryCoders\whatsnextplease-monolith\node_modules\.pnpm\thread-stream@3.1.0\node_modules\thread-stream\lib\worker.js:130:27)
+    at Timeout._onTimeout (D:\STUDY RELATED\HillCountryCoders\whatsnextplease-monolith\node_modules\.pnpm\thread-stream@3.1.0\node_modules\thread-stream\lib\wait.js:51:11)
+    at listOnTimeout (node:internal/timers:594:17)
+    at process.processTimers (node:internal/timers:529:7)
+Emitted 'error' event on ThreadStream instance at:
+    at Immediate.<anonymous> (D:\STUDY RELATED\HillCountryCoders\whatsnextplease-monolith\node_modules\.pnpm\thread-stream@3.1.0\node_modules\thread-stream\index.js:369:12)
+    at process.processImmediate (node:internal/timers:491:21)
+    at process.callbackTrampoline (node:internal/async_hooks:130:17)
+
+Node.js v22.11.0
 node:events:496
       throw er; // Unhandled 'error' event
       ^
@@ -131,21 +144,7 @@ Emitted 'error' event on ThreadStream instance at:
 
 Node.js v22.11.0
  ⨯ Static worker exited with code: 1 and signal: null
-node:events:496
-      throw er; // Unhandled 'error' event
-      ^
-
-TypeError: destination.write is not a function
-    at run (D:\STUDY RELATED\HillCountryCoders\whatsnextplease-monolith\node_modules\.pnpm\thread-stream@3.1.0\node_modules\thread-stream\lib\worker.js:130:27)
-    at Timeout._onTimeout (D:\STUDY RELATED\HillCountryCoders\whatsnextplease-monolith\node_modules\.pnpm\thread-stream@3.1.0\node_modules\thread-stream\lib\wait.js:51:11)
-    at listOnTimeout (node:internal/timers:594:17)
-    at process.processTimers (node:internal/timers:529:7)
-Emitted 'error' event on ThreadStream instance at:
-    at Immediate.<anonymous> (D:\STUDY RELATED\HillCountryCoders\whatsnextplease-monolith\node_modules\.pnpm\thread-stream@3.1.0\node_modules\thread-stream\index.js:369:12)
-    at process.processImmediate (node:internal/timers:491:21)
-    at process.callbackTrampoline (node:internal/async_hooks:130:17)
-
-Node.js v22.11.0
+   Generating static pages (8/35) 
  ⨯ Static worker exited with code: 1 and signal: null
 node:events:496
       throw er; // Unhandled 'error' event
@@ -162,23 +161,23 @@ Emitted 'error' event on ThreadStream instance at:
     at process.callbackTrampoline (node:internal/async_hooks:130:17)
 
 Node.js v22.11.0
- ⨯ Static worker exited with code: 1 and signal: null
 Current user API error: n [Error]: Dynamic server usage: Route /api/auth/current-user couldn't be rendered statically because it used `cookies`. See more info here: https://nextjs.org/docs/messages/dynamic-server-error
-    at l (D:\STUDY RELATED\HillCountryCoders\whatsnextplease-monolith\apps\web\.next\server\chunks\8797.js:1:37158)
-    at p (D:\STUDY RELATED\HillCountryCoders\whatsnextplease-monolith\apps\web\.next\server\chunks\4729.js:1:33516)
-    at p (D:\STUDY RELATED\HillCountryCoders\whatsnextplease-monolith\apps\web\.next\server\app\api\auth\current-user\route.js:1:1242)
-    at D:\STUDY RELATED\HillCountryCoders\whatsnextplease-monolith\node_modules\.pnpm\next@14.2.15_@babel+core@7.28.3_react-dom@18.3.1_react@18.3.1__react@18.3.1\node_modules\next\dist\compiled\next-server\app-route.runtime.prod.js:6:36963
-    at D:\STUDY RELATED\HillCountryCoders\whatsnextplease-monolith\node_modules\.pnpm\next@14.2.15_@babel+core@7.28.3_react-dom@18.3.1_react@18.3.1__react@18.3.1\node_modules\next\dist\server\lib\trace\tracer.js:140:36
-    at NoopContextManager.with (D:\STUDY RELATED\HillCountryCoders\whatsnextplease-monolith\node_modules\.pnpm\next@14.2.15_@babel+core@7.28.3_react-dom@18.3.1_react@18.3.1__react@18.3.1\node_modules\next\dist\compiled\@opentelemetry\api\index.js:1:7062)
-    at ContextAPI.with (D:\STUDY RELATED\HillCountryCoders\whatsnextplease-monolith\node_modules\.pnpm\next@14.2.15_@babel+core@7.28.3_react-dom@18.3.1_react@18.3.1__react@18.3.1\node_modules\next\dist\compiled\@opentelemetry\api\index.js:1:518)
-    at NoopTracer.startActiveSpan (D:\STUDY RELATED\HillCountryCoders\whatsnextplease-monolith\node_modules\.pnpm\next@14.2.15_@babel+core@7.28.3_react-dom@18.3.1_react@18.3.1__react@18.3.1\node_modules\next\dist\compiled\@opentelemetry\api\index.js:1:18093)
-    at ProxyTracer.startActiveSpan (D:\STUDY RELATED\HillCountryCoders\whatsnextplease-monolith\node_modules\.pnpm\next@14.2.15_@babel+core@7.28.3_react-dom@18.3.1_react@18.3.1__react@18.3.1\node_modules\next\dist\compiled\@opentelemetry\api\index.js:1:18854)
-    at D:\STUDY RELATED\HillCountryCoders\whatsnextplease-monolith\node_modules\.pnpm\next@14.2.15_@babel+core@7.28.3_react-dom@18.3.1_react@18.3.1__react@18.3.1\node_modules\next\dist\server\lib\trace\tracer.js:122:103 {
+    at l (D:\STUDY RELATED\HillCountryCoders\whatsnextplease-monolith\apps\web\.next\server\chunks\2110.js:1:37158)
+    at p (D:\STUDY RELATED\HillCountryCoders\whatsnextplease-monolith\apps\web\.next\server\chunks\601.js:1:33520)
+    at c (D:\STUDY RELATED\HillCountryCoders\whatsnextplease-monolith\apps\web\.next\server\app\api\auth\current-user\route.js:1:1240)
+    at D:\STUDY RELATED\HillCountryCoders\whatsnextplease-monolith\node_modules\.pnpm\next@14.2.15_@babel+core@7.28.4_react-dom@18.3.1_react@18.3.1__react@18.3.1\node_modules\next\dist\compiled\next-server\app-route.runtime.prod.js:6:36963
+    at D:\STUDY RELATED\HillCountryCoders\whatsnextplease-monolith\node_modules\.pnpm\next@14.2.15_@babel+core@7.28.4_react-dom@18.3.1_react@18.3.1__react@18.3.1\node_modules\next\dist\server\lib\trace\tracer.js:140:36
+    at NoopContextManager.with (D:\STUDY RELATED\HillCountryCoders\whatsnextplease-monolith\node_modules\.pnpm\next@14.2.15_@babel+core@7.28.4_react-dom@18.3.1_react@18.3.1__react@18.3.1\node_modules\next\dist\compiled\@opentelemetry\api\index.js:1:7062)
+    at ContextAPI.with (D:\STUDY RELATED\HillCountryCoders\whatsnextplease-monolith\node_modules\.pnpm\next@14.2.15_@babel+core@7.28.4_react-dom@18.3.1_react@18.3.1__react@18.3.1\node_modules\next\dist\compiled\@opentelemetry\api\index.js:1:518)
+    at NoopTracer.startActiveSpan (D:\STUDY RELATED\HillCountryCoders\whatsnextplease-monolith\node_modules\.pnpm\next@14.2.15_@babel+core@7.28.4_react-dom@18.3.1_react@18.3.1__react@18.3.1\node_modules\next\dist\compiled\@opentelemetry\api\index.js:1:18093)
+    at ProxyTracer.startActiveSpan (D:\STUDY RELATED\HillCountryCoders\whatsnextplease-monolith\node_modules\.pnpm\next@14.2.15_@babel+core@7.28.4_react-dom@18.3.1_react@18.3.1__react@18.3.1\node_modules\next\dist\compiled\@opentelemetry\api\index.js:1:18854)
+    at D:\STUDY RELATED\HillCountryCoders\whatsnextplease-monolith\node_modules\.pnpm\next@14.2.15_@babel+core@7.28.4_react-dom@18.3.1_react@18.3.1__react@18.3.1\node_modules\next\dist\server\lib\trace\tracer.js:122:103 {
   description: "Route /api/auth/current-user couldn't be rendered statically because it used `cookies`. See more info here: https://nextjs.org/docs/messages/dynamic-server-error",
   digest: 'DYNAMIC_SERVER_USAGE'
 }
-   Generating static pages (15/31) 
-   Generating static pages (23/31) 
+ ⨯ Static worker exited with code: 1 and signal: null
+   Generating static pages (17/35) 
+   Generating static pages (26/35) 
 node:events:496
       throw er; // Unhandled 'error' event
       ^
@@ -192,13 +191,13 @@ Emitted 'error' event on ThreadStream instance at:
     at process.callbackTrampoline (node:internal/async_hooks:130:17)
 
 Node.js v22.11.0
- ✓ Generating static pages (31/31)
+ ✓ Generating static pages (35/35)
    Finalizing page optimization ...
    Collecting build traces ...
 
 Route (app)                              Size     First Load JS
 ┌ ƒ /                                    337 B          87.8 kB
-├ ○ /_not-found                          880 B          88.3 kB
+├ ○ /_not-found                          879 B          88.3 kB
 ├ ƒ /api/auth/current-user               0 B                0 B
 ├ ○ /api/skills                          0 B                0 B
 ├ ƒ /api/task/doesTaskExists             0 B                0 B
@@ -208,34 +207,38 @@ Route (app)                              Size     First Load JS
 ├ ƒ /api/tasks/unassignedTasks           0 B                0 B
 ├ ƒ /api/user/doesUserExists             0 B                0 B
 ├ ƒ /api/users/taskAgentList             0 B                0 B
-├ ƒ /clients                             7.91 kB         172 kB
-├ ƒ /clients/[clientId]                  6.01 kB         753 kB
-├ ƒ /clients/addclient                   2.02 kB         277 kB
-├ ƒ /home                                3.69 kB         247 kB
+├ ƒ /clients                             7.93 kB         172 kB
+├ ƒ /clients/[clientId]                  6.01 kB         754 kB
+├ ƒ /clients/addclient                   2.01 kB         277 kB
+├ ○ /forgot-password                     4.49 kB         106 kB
+├ ƒ /home                                3.68 kB         247 kB
 ├ ƒ /messages                            1.75 kB         100 kB
 ├ ƒ /notifications/me                    10.1 kB         166 kB
-├ ƒ /settings/billing                    197 B          87.6 kB
+├ ○ /resend-verification                 4.38 kB        98.6 kB
+├ ○ /reset-password                      5.85 kB         107 kB
+├ ƒ /settings/billing                    193 B          87.6 kB
 ├ ƒ /settings/myprofile                  12.2 kB         285 kB
 ├ ƒ /settings/notifications              8.46 kB         127 kB
 ├ ƒ /settings/permissions                8.27 kB         131 kB
-├ ƒ /settings/picklists                  24.1 kB         714 kB
-├ ○ /signin                              9.42 kB         158 kB
-├ ○ /signup                              4.02 kB         174 kB
+├ ƒ /settings/picklists                  24.1 kB         715 kB
+├ ○ /signin                              9.44 kB         158 kB
+├ ○ /signup                              4.03 kB         174 kB
 ├ ƒ /skills                              1.53 kB         209 kB
 ├ ƒ /taskAgents                          11.3 kB         154 kB
-├ ƒ /taskOfferings                       5.95 kB         767 kB
+├ ƒ /taskOfferings                       5.97 kB         768 kB
 ├ ƒ /taskOfferings/(.)taskId             943 B           668 kB
-├ ƒ /taskOfferings/[taskId]              641 B           667 kB
-├ ƒ /users                               13.9 kB         305 kB
-├ ƒ /users/[userId]                      5.06 kB         883 kB
-└ ƒ /users/adduser                       2.69 kB         285 kB
+├ ƒ /taskOfferings/[taskId]              638 B           668 kB
+├ ƒ /users                               14 kB           305 kB
+├ ƒ /users/[userId]                      5.06 kB         884 kB
+├ ƒ /users/adduser                       2.69 kB         285 kB
+└ ○ /verify-email                        3.72 kB        97.9 kB
 + First Load JS shared by all            87.4 kB
-  ├ chunks/216d3138-7afcefe73bd1383a.js  53.6 kB
-  ├ chunks/3844-7c9ccc1ab55a30f5.js      31.7 kB
+  ├ chunks/600a3b68-b8a1ef61c644e288.js  53.6 kB
+  ├ chunks/7551-d2b933f66bb69183.js      31.8 kB
   └ other shared chunks (total)          2.03 kB
 
 
-ƒ Middleware                             79.6 kB
+ƒ Middleware                             80 kB
 
 ○  (Static)   prerendered as static content
 ƒ  (Dynamic)  server-rendered on demand

--- a/apps/web/app/(dashboard)/home/@taskSupervisor/@recentUnassignedTasks/page.tsx
+++ b/apps/web/app/(dashboard)/home/@taskSupervisor/@recentUnassignedTasks/page.tsx
@@ -10,23 +10,31 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import { Badge } from '@/components/ui/badge';
-import { Card, CardHeader, CardTitle, CardContent, CardFooter } from '@/components/ui/card';
+import { Card, CardHeader, CardContent, CardFooter, CardTitle } from '@/components/ui/card';
 import { transformEnumValue } from '@/utils/utils';
 import { useEffect, useState } from 'react';
 import { getCurrentUser } from '@/utils/user';
 import { Roles } from '@prisma/client';
-import { TaskType } from '@/utils/validationSchemas';
+import { TaskTable } from '@/utils/validationSchemas';
 import { ClipboardCheck, Loader2, PlusCircle } from 'lucide-react';
 import { CallToAction } from '@/components/CallToAction';
 import { LinkButton } from '@/components/ui/LinkButton';
-import { taskApiClient } from '@/utils/taskApi'; // UPDATED: Use backend API
+import { tasksByType } from '@/db/repositories/tasks/tasksByType';
+
 import { taskPriorityColors, taskStatusColors } from '@/utils/taskUtilColorClasses';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
+import { DurationEnum } from '@/types';
+import { useRouter } from 'next/navigation';
 
 const RecentUnassignedTasksPage = () => {
-  const [tasks, setTasks] = useState<TaskType[]>([]);
+  const router = useRouter();
+  const [tasks, setTasks] = useState<TaskTable[] | null>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-
+  const [activeTab, setActiveTab] = useState<'unassigned' | 'my-tasks'>('unassigned');
+  const handleRowClick = (taskID: string) => {
+    router.push(`/taskOfferings/${taskID}`);
+  };
   useEffect(() => {
     const fetchTasks = async () => {
       try {
@@ -34,9 +42,17 @@ const RecentUnassignedTasksPage = () => {
         const user = await getCurrentUser();
         if (user?.role?.name === Roles.TASK_SUPERVISOR) {
           // UPDATED: Use backend API instead of Next.js API route
-          const response = await taskApiClient.getUnassignedTasks(undefined, 5);
+          const response = await tasksByType(
+            activeTab,
+            user?.role?.name,
+            null,
+            5,
+            '',
+            DurationEnum.ALL,
+            user?.id
+          );
 
-          if (response.success) {
+          if (response && response.success) {
             setTasks(response.tasks);
           } else {
             throw new Error(response.message || 'Failed to fetch unassigned tasks');
@@ -50,102 +66,126 @@ const RecentUnassignedTasksPage = () => {
       }
     };
     fetchTasks();
-  }, []);
+  }, [activeTab]);
 
   return (
-    <Card className="shadow-sm">
-      <CardHeader className="pb-3">
-        <CardTitle className="text-2xl font-bold flex items-center gap-2">
-          <ClipboardCheck className="h-6 w-6 text-primary" />
-          Recent Unassigned Tasks
-        </CardTitle>
-      </CardHeader>
+    <Tabs
+      defaultValue={'unassigned'}
+      className="w-full"
+      onValueChange={value => {
+        setActiveTab(value as 'unassigned' | 'my-tasks');
+      }}
+    >
+      <Card className="shadow-sm">
+        <CardHeader className="pb-3">
+          <CardTitle className="text-2xl font-bold flex items-center gap-2">
+            <ClipboardCheck className="h-6 w-6 text-primary" />
+            Tasks
+          </CardTitle>
+          <TabsList className="flex gap-4 bg-transparent items-start justify-start">
+            <TabsTrigger value="unassigned" className="text-sm">
+              Unassigned Tasks
+            </TabsTrigger>
 
-      <CardContent>
-        {isLoading ? (
-          <div className="flex justify-center items-center h-64">
-            <Loader2 className="h-8 w-8 animate-spin text-primary" />
-          </div>
-        ) : error ? (
-          <CallToAction
-            title="Error Loading Tasks"
-            link="/taskOfferings"
-            description={error}
-            action="Go to Tasks"
-            helperText="Try again later or contact support if the problem persists"
-            variant="destructive"
-            iconType="alert"
-            className="my-6"
-          />
-        ) : tasks.length === 0 ? (
-          <CallToAction
-            title="No unassigned tasks"
-            link="/taskOfferings"
-            description="There are currently no unassigned tasks in the system"
-            action="Create New Task"
-            helperText="You can create a new task or wait for users to submit tasks"
-            variant="primary"
-            iconType="plus"
-            className="my-6"
-          />
-        ) : (
-          <Table className="border rounded-md">
-            <TableHeader className="bg-muted/50">
-              <TableRow>
-                <TableHead className="font-medium">Task Details</TableHead>
-                <TableHead className="font-medium">Priority</TableHead>
-                <TableHead className="font-medium">Status</TableHead>
-                <TableHead className="text-right font-medium">Due Date</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {tasks.map(task => (
-                <TableRow
-                  key={task.id}
-                  className="hover:bg-muted/30 cursor-pointer transition-colors"
-                >
-                  <TableCell className="font-medium">
-                    {task.taskCategory?.categoryName || 'No Category'}
-                  </TableCell>
-                  <TableCell>
-                    <Badge
-                      className={`${taskPriorityColors[task.priority.priorityName]} py-1.5 px-2.5 text-xs font-medium`}
-                    >
-                      {transformEnumValue(task.priority.priorityName)}
-                    </Badge>
-                  </TableCell>
-                  <TableCell>
-                    <Badge
-                      className={`${taskStatusColors[task.status.statusName]} py-1.5 px-2.5 text-xs font-medium`}
-                    >
-                      {transformEnumValue(task.status.statusName)}
-                    </Badge>
-                  </TableCell>
-                  <TableCell className="text-right">
-                    {task.dueDate ? new Date(task.dueDate).toLocaleDateString() : 'No due date'}
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
+            <TabsTrigger value="my-tasks" className="text-sm">
+              My Tasks
+            </TabsTrigger>
+          </TabsList>
+        </CardHeader>
+
+        <CardContent>
+          {['unassigned', 'my-tasks'].map((ele, index) => (
+            <TabsContent value={ele} key={index}>
+              {isLoading ? (
+                <div className="flex justify-center items-center h-[200px]">
+                  <Loader2 className="h-8 w-8 animate-spin text-primary" />
+                </div>
+              ) : error ? (
+                <CallToAction
+                  title="Error Loading Tasks"
+                  link="/taskOfferings"
+                  description={error}
+                  action="Go to Tasks"
+                  helperText="Try again later or contact support if the problem persists"
+                  variant="destructive"
+                  iconType="alert"
+                  className="my-6"
+                />
+              ) : tasks?.length === 0 ? (
+                <CallToAction
+                  title="No unassigned tasks"
+                  link="/taskOfferings"
+                  description="There are currently no unassigned tasks in the system"
+                  action="Create New Task"
+                  helperText="You can create a new task or wait for users to submit tasks"
+                  variant="primary"
+                  iconType="plus"
+                  className="my-6"
+                />
+              ) : (
+                <Table className="border rounded-md">
+                  <TableHeader className="bg-muted/50">
+                    <TableRow>
+                      <TableHead className="font-medium">Task Details</TableHead>
+                      <TableHead className="font-medium">Priority</TableHead>
+                      <TableHead className="font-medium">Status</TableHead>
+                      <TableHead className="text-right font-medium">Due Date</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  {}
+                  <TableBody>
+                    {tasks?.map(task => (
+                      <TableRow
+                        key={task.id}
+                        className="hover:bg-muted/30 cursor-pointer transition-colors"
+                        onClick={() => handleRowClick(task.id)}
+                      >
+                        <TableCell className="font-medium">
+                          {task.taskCategory?.categoryName || 'No Category'}
+                        </TableCell>
+                        <TableCell>
+                          <Badge
+                            className={`${taskPriorityColors[task.priority.priorityName]} py-1.5 px-2.5 text-xs font-medium`}
+                          >
+                            {transformEnumValue(task.priority.priorityName)}
+                          </Badge>
+                        </TableCell>
+                        <TableCell>
+                          <Badge
+                            className={`${taskStatusColors[task.status.statusName]} py-1.5 px-2.5 text-xs font-medium`}
+                          >
+                            {transformEnumValue(task.status.statusName)}
+                          </Badge>
+                        </TableCell>
+                        <TableCell className="text-right">
+                          {task.dueDate
+                            ? new Date(task.dueDate).toLocaleDateString()
+                            : 'No due date'}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              )}
+            </TabsContent>
+          ))}
+        </CardContent>
+        {tasks && tasks?.length > 0 && (
+          <CardFooter className="pt-1 pb-4 flex justify-end">
+            <LinkButton
+              href="/taskOfferings"
+              className="flex items-center gap-1"
+              variant={'outline'}
+              size={'sm'}
+              prefetch={true}
+            >
+              <span>View All Tasks</span>
+              <PlusCircle className="h-4 w-4 ml-1" />
+            </LinkButton>
+          </CardFooter>
         )}
-      </CardContent>
-
-      {tasks.length > 0 && (
-        <CardFooter className="pt-1 pb-4 flex justify-end">
-          <LinkButton
-            href="/taskOfferings"
-            className="flex items-center gap-1"
-            variant={'outline'}
-            size={'sm'}
-            prefetch={true}
-          >
-            <span>View All Tasks</span>
-            <PlusCircle className="h-4 w-4 ml-1" />
-          </LinkButton>
-        </CardFooter>
-      )}
-    </Card>
+      </Card>
+    </Tabs>
   );
 };
 

--- a/apps/web/app/api/users/taskAgentList/route.ts
+++ b/apps/web/app/api/users/taskAgentList/route.ts
@@ -1,40 +1,45 @@
-import prisma from "@/db/db";
-import logger from "@/utils/logger";
-import {
-  getAllUsersInputSchema,
-  getAllUsersOutputSchema,
-} from "@/utils/validationSchemas";
-import { Roles } from "@prisma/client";
-import { NextResponse } from "next/server";
+import prisma from '@/db/db';
+import logger from '@/utils/logger';
+import { getAllUsersInputSchema, getAllUsersOutputSchema } from '@/utils/validationSchemas';
+import { Roles } from '@prisma/client';
+import { NextResponse } from 'next/server';
 
 export async function GET(request: Request) {
   try {
     const url = new URL(request.url);
     const searchParams = url.searchParams;
     const parsedParams = getAllUsersInputSchema.parse({
-      role: searchParams.get("role"),
+      role: searchParams.get('role'),
+      skills: searchParams.get('skills')?.split(',') ?? [],
     });
 
-    const { role } = parsedParams;
-    const allowedRoles: Roles[] = [
-      Roles.TASK_SUPERVISOR,
-      Roles.CLIENT,
-      Roles.SUPER_USER,
-    ];
+    const { role, skills } = parsedParams;
+    const allowedRoles: Roles[] = [Roles.TASK_SUPERVISOR, Roles.CLIENT, Roles.SUPER_USER];
 
     if (!allowedRoles.includes(role)) {
-      return NextResponse.json(
-        { success: false, message: "Unauthorized Role" },
-        { status: 403 },
-      );
+      return NextResponse.json({ success: false, message: 'Unauthorized Role' }, { status: 403 });
     }
-
     const users = await prisma.user.findMany({
       where: {
         role: {
-          name: Roles.TASK_AGENT,
+          name: {
+            in: [Roles.TASK_AGENT, Roles.TASK_SUPERVISOR],
+          },
         },
+        // If no skills are provided, do not filter by userSkills
+        ...(skills.length > 0 && {
+          userSkills: {
+            some: {
+              skill: {
+                name: {
+                  in: skills,
+                },
+              },
+            },
+          },
+        }),
       },
+
       select: {
         id: true,
         firstName: true,
@@ -52,10 +57,10 @@ export async function GET(request: Request) {
 
     return NextResponse.json(validatedResponse);
   } catch (error) {
-    logger.error(error, "Error fetching users:");
+    logger.error(error, 'Error fetching users:');
     return NextResponse.json(
-      { success: false, message: "An error occurred while fetching users" },
-      { status: 500 },
+      { success: false, message: 'An error occurred while fetching users' },
+      { status: 500 }
     );
   }
 }

--- a/apps/web/components/common/EditTaskDialog.tsx
+++ b/apps/web/components/common/EditTaskDialog.tsx
@@ -179,6 +179,8 @@ export default function EditTaskDialog({
     },
     mode: 'onSubmit',
   });
+  const watchedSkills = form.watch('skills');
+
   const selectedAssigneeId = form.watch('assignedToId');
 
   /**
@@ -332,13 +334,12 @@ export default function EditTaskDialog({
       items,
     }));
   };
-
   const fetchUsers = async () => {
     if (!canAssignTasks) {
       return;
     }
     try {
-      const response = await usersList(role ?? Roles.TASK_SUPERVISOR);
+      const response = await usersList(role ?? Roles.TASK_SUPERVISOR, form.getValues('skills'));
       if (response.success) {
         // Fetch task counts for users and update state
         const usersWithTaskCounts = await fetchUserTaskCounts(response.users);
@@ -387,11 +388,14 @@ export default function EditTaskDialog({
       }
     }
     if (open) {
-      fetchUsers();
       fetchSkills();
       fetchTaskMetadata();
     }
   }, [task, open, form]);
+
+  useEffect(() => {
+    fetchUsers();
+  }, [watchedSkills]);
 
   const [, startTransition] = useTransition();
 

--- a/apps/web/components/tasks/TaskSuperVisorList.tsx
+++ b/apps/web/components/tasks/TaskSuperVisorList.tsx
@@ -296,7 +296,7 @@ export const TaskSuperVisorList = ({
           <TabsTrigger value="assigned" className="text-sm">
             Assigned
           </TabsTrigger>
-          {role === Roles.TASK_AGENT && (
+          {(role === Roles.TASK_AGENT || role === Roles.TASK_SUPERVISOR) && (
             <TabsTrigger value="my-tasks" className="text-sm">
               My Tasks
             </TabsTrigger>

--- a/apps/web/db/repositories/users/usersList.ts
+++ b/apps/web/db/repositories/users/usersList.ts
@@ -1,18 +1,22 @@
-"use client";
-import { Roles } from "@prisma/client";
-import { handleError } from "@/utils/errorHandler";
-import { getAllUsersOutputSchema } from "@/utils/validationSchemas";
-import { z } from "zod";
+'use client';
+import { Roles } from '@prisma/client';
+import { handleError } from '@/utils/errorHandler';
+import { getAllUsersOutputSchema } from '@/utils/validationSchemas';
+import { z } from 'zod';
 
 type GetUsersSchema = z.infer<typeof getAllUsersOutputSchema>;
 
-export const usersList = async (role: Roles): Promise<GetUsersSchema> => {
+export const usersList = async (role: Roles, skills?: string[]): Promise<GetUsersSchema> => {
   try {
-    const response = await fetch(`/api/users/taskAgentList?role=${role}`);
+    // Only include skills in the query if it has values
+    const query =
+      skills && skills.length > 0 ? `?role=${role}&skills=${skills.join(',')}` : `?role=${role}`;
+
+    const response = await fetch(`/api/users/taskAgentList${query}`);
 
     if (!response.ok) {
-      const error = new Error("Failed to fetch users");
-      return handleError(error, "usersList") as GetUsersSchema;
+      const error = new Error('Failed to fetch users');
+      return handleError(error, 'usersList') as GetUsersSchema;
     }
 
     const jsonData = await response.json();
@@ -21,6 +25,6 @@ export const usersList = async (role: Roles): Promise<GetUsersSchema> => {
 
     return data;
   } catch (error) {
-    return handleError(error, "usersList") as GetUsersSchema;
+    return handleError(error, 'usersList') as GetUsersSchema;
   }
 };

--- a/apps/web/utils/validationSchemas.ts
+++ b/apps/web/utils/validationSchemas.ts
@@ -677,6 +677,7 @@ export const getAllUsersOutputSchema = errorSchema.merge(
 
 export const getAllUsersInputSchema = z.object({
   role: z.nativeEnum(Roles),
+  skills: z.array(z.string()),
 });
 
 export const TaskByPrioritySchema = z.object({

--- a/packages/types/.turbo/turbo-build.log
+++ b/packages/types/.turbo/turbo-build.log
@@ -1,5 +1,4 @@
 
-
-> @wnp/types@1.0.0 build /Users/syedsibtealibaqar/Documents/whatsnextplease-monolith/packages/types
+> @wnp/types@1.0.0 build D:\STUDY RELATED\HillCountryCoders\whatsnextplease-monolith\packages\types
 > tsc
 


### PR DESCRIPTION
**Files Modified:**
1-apps/backend/api/services/task.service.ts
2-apps/web/app/(dashboard)/home/@taskSupervisor/@recentUnassignedTasks/page.tsx
3-apps/web/app/api/users/taskAgentList/route.ts
4-apps/web/components/common/EditTaskDialog.tsx
5-apps/web/components/tasks/CreateTaskContainer.tsx
6-apps/web/components/tasks/TaskSuperVisorList.tsx
7-apps/web/db/repositories/users/usersList.ts
8-apps/web/utils/validationSchemas.ts


**Approach:**
Updated the Task Supervisor and now tasks can be assigned to him as well. Task Supervisor can now see his own tasks in task offering page as well as home page. 
Updated the create and edit task modal such that when one or more skill is selected then users with those skills are fetched and displayed when assigning task. If no skill is selected then all users are fetched.


**Recording:**
https://www.loom.com/share/84b2fd0f989c48a0bf273bd482c289a2?sid=c38c84b5-9a80-403c-9a6c-17b15f09a3db