### PR TITLE
fix: fixed attach file error

### DIFF
--- a/apps/web/components/comments/CommentFileUpload.tsx
+++ b/apps/web/components/comments/CommentFileUpload.tsx
@@ -117,7 +117,7 @@ const CommentFileUpload = forwardRef<CommentFileUploadRef, CommentFileUploadProp
           const payload = {
             fileName: file.name,
             fileSize: fileSizeInKb,
-            uploadedBy: user?.name || 'Unknown',
+            uploadedBy: user?.username || 'Unknown',
             createdAt: new Date().toISOString(),
             role: user?.role?.name || 'USER',
             userId: user?.id || '',
@@ -219,7 +219,9 @@ const CommentFileUpload = forwardRef<CommentFileUploadRef, CommentFileUploadProp
       } catch (error) {
         toast({
           title: 'Error',
-          description: 'An error occurred while deleting the file: ' + (error instanceof Error ? error.message : String(error)),
+          description:
+            'An error occurred while deleting the file: ' +
+            (error instanceof Error ? error.message : String(error)),
           variant: 'destructive',
           icon: <CircleX size={20} />,
         });

--- a/apps/web/components/common/FileUploadArea.tsx
+++ b/apps/web/components/common/FileUploadArea.tsx
@@ -122,7 +122,7 @@ const FileUploadArea = ({ onFilesChange }: FileUploadAreaProps) => {
         const payload = {
           fileName: nextFile.file.name,
           fileSize: fileSizeInKb,
-          uploadedBy: user?.name,
+          uploadedBy: user?.username,
           createdAt: new Date().toISOString(),
           role: user?.role?.name,
           userId: user?.id,


### PR DESCRIPTION
**Files Modified:**
1-apps/web/components/comments/CommentFileUpload.tsx
2-apps/web/components/common/FileUploadArea.tsx

**Approach:**
1- The uploadedBy variable was being sent undefined in the backend when we try to upload files. We were trying to access "name" variable from user object and it does not exist. I changed the variable to "username" and it fixed the issue because "username" exits in the user object. 

2- The reason we were able to upload files when editing a task was because of condition uploadedBy: user?.name || 'Unknown',
since user?.name did not exist then "Unknown" was being sent in uploadedBy variable and thats why api was working during editing task.

**Recording:**
https://www.loom.com/share/a23d66457ec9433981b68a2681ddbbf0