### PR TITLE
fix: fixed pagination and adavanced filter issues

### DIFF
--- a/apps/web/components/tasks/TaskSuperVisorList.tsx
+++ b/apps/web/components/tasks/TaskSuperVisorList.tsx
@@ -72,6 +72,8 @@ export const TaskSuperVisorList = ({
     | 'my-tasks';
   const assignedToFilter = searchParams.get('assignedTo') || undefined;
 
+  // Reset pageIndex when pageSize changes
+
   // Handle advanced page changes
   const handleAdvancedPageChange = async (newPageIndex: number) => {
     if (!searchResults) return;
@@ -90,7 +92,7 @@ export const TaskSuperVisorList = ({
   };
 
   const paginatedAdvancedData = useMemo(() => {
-    if (!searchResults) return [];
+    if (!searchResults || !Array.isArray(searchResults)) return [];
     const start = pageIndex * pageSize;
     return searchResults.slice(start, start + pageSize);
   }, [searchResults, pageIndex, pageSize]);
@@ -219,6 +221,25 @@ export const TaskSuperVisorList = ({
       }
     }
   }, [searchResults, advancedFilterTaskIds, hasNextCursor]);
+
+  useEffect(() => {
+    setPageIndex(0);
+
+    if (filterMode === 'normal') {
+      setCursor(null);
+      setData([]);
+      fetchNormalTasks(null);
+    }
+
+    // ✅ FIX for advanced mode
+    if (filterMode === 'advanced' && searchResults) {
+      const requiredItems = pageSize; // page 1 → need at least pageSize items
+
+      if (searchResults.length < requiredItems && hasNextCursor) {
+        loadMore(); // 🔥 fetch more data
+      }
+    }
+  }, [pageSize]);
 
   const renderTaskTable = () => (
     <UserTasksTable

--- a/apps/web/hooks/useAdvancedFilter.ts
+++ b/apps/web/hooks/useAdvancedFilter.ts
@@ -188,7 +188,17 @@ export function useAdvancedFilter({
       setIsSearching(false);
       setLoading(false);
     }
-  }, [conditions, logicalOperator, toast]);
+  }, [conditions, logicalOperator, toast, view]);
+
+  useEffect(() => {
+    if (
+      (view === 'kanban' && searchResults) ||
+      (view === 'list' && searchResults) ||
+      (view === 'timeline' && searchResults)
+    ) {
+      executeSearch();
+    }
+  }, [view]);
 
   // Load more results
   const loadMore = useCallback(


### PR DESCRIPTION
**Files Modified:**
1-apps/web/components/tasks/TaskSuperVisorList.tsx
2-apps/web/hooks/useAdvancedFilter.ts

**Approach:**

1- Fixed the pagination of table when we go to page greater than 1 and then change page size from 10 to any other then it would not show the updated result and page was also not being reset to page 1 as well.

2- When we applied advanced filters on table or gantt chart and then change view to kanban then it would cause error as kanban expects different structure (task object) for tasks while table and gantt takes task array as input.

