### PR TITLE
fix: fixed serial no. not being assigned

### DIFF
--- a/apps/backend/api/services/taskCategory.service.ts
+++ b/apps/backend/api/services/taskCategory.service.ts
@@ -1,5 +1,7 @@
 import { TaskCategoryCreateDto } from '@wnp/types';
 import prisma from '../config/db';
+import { TaskSerialNumberService } from './taskSerialNumber.service';
+const serialNumberService = new TaskSerialNumberService();
 
 export class TaskCategoryService {
   async getAllTaskCategories() {
@@ -18,11 +20,27 @@ export class TaskCategoryService {
     });
   }
   async createTaskCategory(taskCategory: TaskCategoryCreateDto) {
-    return await prisma.taskCategory.create({
+    //Create category first
+    const createdCategory = await prisma.taskCategory.create({
       data: {
         categoryName: taskCategory.categoryName,
       },
     });
+
+    //Generate prefix using created category id
+    const suggestion = await serialNumberService.suggestPrefixForCategory(createdCategory.id);
+
+    //Update same category with generated prefix
+    const updatedCategory = await prisma.taskCategory.update({
+      where: {
+        id: createdCategory.id,
+      },
+      data: {
+        prefix: suggestion.prefix,
+      },
+    });
+
+    return updatedCategory;
   }
   async updateTaskCategory() {
     return {};

--- a/apps/web/components/tasks/SerialNumberInput.tsx
+++ b/apps/web/components/tasks/SerialNumberInput.tsx
@@ -41,7 +41,7 @@ export function SerialNumberPrefixInput({
           // If user hasnt set a custom prefix, use the suggested one
           if (!customPrefix) {
             setCustomPrefix(response.data.prefix);
-            onChange(undefined);
+            onChange(response.data.prefix);
           }
         }
       } catch (error) {

--- a/apps/web/utils/tasks/taskAPI.ts
+++ b/apps/web/utils/tasks/taskAPI.ts
@@ -26,6 +26,7 @@ export interface UpdateTaskParams {
   overTime?: string;
   dueDate?: Date | null;
   initialComment?: string;
+  customPrefix?: string;
 }
 
 class TaskAPI {


### PR DESCRIPTION
- Serial No. was not being assigned to a newly created task because task category prefix was being created but not passed to the backend. So now I updated the system such that whenever a new category is created then predix for the category is also created at the same time and saved in the task category model.