### PR TITLE
fix: fixed task page details not found for some categories

### DIFF
--- a/apps/web/utils/validationSchemas.ts
+++ b/apps/web/utils/validationSchemas.ts
@@ -281,7 +281,7 @@ export const TaskSchema = z.object({
   }),
   taskCategory: z.object({
     categoryName: z.string(),
-    prefix: z.string(),
+    prefix: z.string().nullable(),
   }),
   assignedTo: z
     .object({


### PR DESCRIPTION
Fixed task not found page as some task category prefix was returning null and it was expecting a string so updated the validation to accept null
